### PR TITLE
Mit diesem scheint das bauen geklappt zu haben

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM adoptopenjdk:12.0.1_12-jdk-openj9-0.14.1
+CMD ["java", "-jar", "/opt/app/japp.jar"]


### PR DESCRIPTION
aber das "run" funktioniert noch nicht.
udo docker build -t japp .
ERRO[0002] Can't add file /home/jennbull/.dropbox/command_socket to tar: archive/tar: sockets not supported 
ERRO[0002] Can't add file /home/jennbull/.dropbox/iface_socket to tar: archive/tar: sockets not supported 
Sending build context to Docker daemon  1.692GB
Step 1/2 : FROM adoptopenjdk:12.0.1_12-jdk-openj9-0.14.1
12.0.1_12-jdk-openj9-0.14.1: Pulling from library/adoptopenjdk
7413c47ba209: Pull complete 
0fe7e7cbb2e8: Pull complete 
1d425c982345: Pull complete 
344da5c95cec: Pull complete 
e494012c721a: Pull complete 
520cd31d3fbd: Pull complete 
Digest: sha256:8b706f400d75898ac3c9363f97f8f0b6f71453bd57484fa665686b0a1e83b1de
Status: Downloaded newer image for adoptopenjdk:12.0.1_12-jdk-openj9-0.14.1
 ---> 4de8b09586c6
Step 2/2 : CMD ["java", "-jar", "/opt/app/japp.jar"]
 ---> Running in 1f0797fc0cd0
Removing intermediate container 1f0797fc0cd0
 ---> 031d3901733e
Successfully built 031d3901733e
Successfully tagged japp:latest